### PR TITLE
Fix typo in W1510.md

### DIFF
--- a/plerr/errors/stdlib/W1510.md
+++ b/plerr/errors/stdlib/W1510.md
@@ -24,5 +24,5 @@ is.
 
 ### Related resources:
 
-- [`subprocess.run` documentation](https//docs.python.org/3/library/subprocess.html#subprocess.run)
+- [`subprocess.run` documentation](https://docs.python.org/3/library/subprocess.html#subprocess.run)
 - [Issue Tracker](https://github.com/PyCQA/pylint/issues?q=is%3Aissue+%22subprocess-run-check%22+OR+%22W1510%22)


### PR DESCRIPTION
Missing colon was causing a relative URL link