### PR TITLE
change code block language from pyton to console

### DIFF
--- a/plerr/errors/variables/E0604.md
+++ b/plerr/errors/variables/E0604.md
@@ -2,7 +2,7 @@
 
 ### :x: Problematic code:
 
-```python
+```console
 cat > test.py <<EOF
 __all__ = [Test, Foo]
 
@@ -18,7 +18,7 @@ EOF
 
 ### :heavy_check_mark: Correct code:
 
-```python
+```console
 cat > test.py <<EOF
 __all__ = ['Test', 'Foo']
 


### PR DESCRIPTION
this example need to change code block language from `python` to `console`.
Other exmple of using `cat` command set `console`.

Please check it.