### PR TITLE
Update C0113.md

### DIFF
--- a/plerr/errors/refactoring/C0113.md
+++ b/plerr/errors/refactoring/C0113.md
@@ -10,7 +10,7 @@ if not not input():
 ### :heavy_check_mark: Correct code:
 
 ```python
-if not input():
+if input():
     pass
 ```
 


### PR DESCRIPTION
A double negation is positive, so the equivalent code would remove both `not` instead of just one.